### PR TITLE
Fix:utils/union_api.py unexp resp protection

### DIFF
--- a/utils/union_api.py
+++ b/utils/union_api.py
@@ -9,8 +9,20 @@ class UnionAPI:
 
     def queryPublicAPI(self) -> list[dict]:
         response = requests.get(self.__api_root_public)
-        return json.loads(response.text)
-
+        # (30/11/2023 kontornl) 增加响应码非 200 以及格式非 JSON 防护
+        if response.status_code == 200:
+            try:
+                return json.loads(response.text)
+            except json.JSONDecodeError:
+                raise json.JSONDecodeError('queryPublicAPI() failed caused by not JSON-formatted response')
+        else:
+            raise Exception(f'queryPublicAPI() failed, HTTP status code {response.status_code}')
     def queryAPI(self) -> list[dict]:
         response = requests.get(self.__api_root, headers={"X-Union-Network-Query-Token" : FRPC_UNION_MEMBER_KEY})
-        return json.loads(response.text)
+        if response.status_code == 200:
+            try:
+                return json.loads(response.text)
+            except json.JSONDecodeError:
+                raise json.JSONDecodeError('queryAPI() failed caused by not JSON-formatted response')
+        else:
+            raise Exception(f'queryAPI() failed, HTTP status code {response.status_code}. Invalid FRPC_UNION_MEMBER_KEY?')


### PR DESCRIPTION
针对异常 HTTP 响应，在请求 API 方法中做了防护，使得程序因此异常退出时提供明确的问题描述。

简略地测试了防护，对异常响应码的防护有效。另外，强烈建议此类方法内不要做 JSON 解析，若必须解析则需要 try-except 环绕。